### PR TITLE
Layout for devise pages, plus minor fixes

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -88,22 +88,6 @@ body {
   transition: 0.5s;
 }
 
-.button-pink {
-  background: #F88585;
-  border-radius: 30px;
-  color: #FFFFFF;
-  font-family: Open Sans;
-  font-size: 17px;
-  border: none;
-  padding: 5px 20px;
-}
-
-.button-pink:hover {
-  background-color: #FFFFFF;
-  color: #F88585;
-  transition: 0.5s;
-}
-
 .button-purple {
   background: transparent;
   border-radius: 30px;
@@ -174,6 +158,64 @@ body {
 .bird {
   width: 100px;
 }
+
+.divisor {
+  width: 150px;
+  height: 8px;
+  background-image: linear-gradient(to right, #FE5F55, #F3A5A1);
+  margin: 0 0 35px 0;
+}
+
+.link-devise:link,
+.link-devise:hover,
+.link-devise:visited,
+.link-devise:active {
+  color: #C1C1C1;
+  font-family: Open Sans;
+}
+.open-sans {
+  font-family: Open Sans;
+}
+
+// Botões //
+
+.btn-custom {
+    font-family: Open Sans;
+    font-size: 16px;
+    font-weight: 400;
+    color: #fff;
+    cursor: pointer;
+    margin: 20px;
+    height: 35px;
+    text-align:center;
+    border: none;
+    background-size: 300% 100%;
+    padding: 5px 20px;
+
+    border-radius: 40px;
+    moz-transition: all .4s ease-in-out;
+    -o-transition: all .4s ease-in-out;
+    -webkit-transition: all .4s ease-in-out;
+    transition: all .4s ease-in-out;
+}
+
+.btn-custom:hover {
+    background-position: 100% 0;
+    moz-transition: all .4s ease-in-out;
+    -o-transition: all .4s ease-in-out;
+    -webkit-transition: all .4s ease-in-out;
+    transition: all .4s ease-in-out;
+}
+
+.btn-custom:focus {
+    outline: none;
+}
+
+.btn-custom.pink {
+       background-image: linear-gradient(to right, #F88585, #f15e64, #e14e53, #e2373f);  box-shadow: 0 5px 15px rgba(242, 97, 103, .4);
+}
+
+// Responsividade //
 
 @media(max-width: 1920px) {
   .background-top {

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,18 +1,28 @@
-<h2>Forgot your password?</h2>
+<div class="container mt-5">
+  <div class="row justify-content-center align-items-center" style="margin-top: 150px;">
+    <div class="col-md-4">
+        <form class="form p-4" method="post">
+          <h3 class="text-center mb-3 open-sans">Esqueceu sua senha?</h3>
+        <div class="row justify-content-center align-items-center">
+          <div class="divisor"></div>
+        </div>
+          <p class="text-center mb-2 open-sans">Informe seu email para que possamos te ajudar a criar uma nova. </p>
+          <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+            <%= f.error_notification %>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_notification %>
+            <div class="form-inputs">
+              <%= f.input :email, :label => ' ',
+                          required: true,
+                          autofocus: true,
+                          input_html: { autocomplete: "email" } %>
+            </div>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
+            <div class="row justify-content-center mt-4">
+              <%= f.submit "Enviar", class:"btn-custom pink"%>
+            </div>
+          <% end %>
+        </form>
+    </div>
   </div>
+</div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,12 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container mt-5">
+  <div class="row justify-content-center align-items-center" style="margin-top: 50px;">
+    <div class="col-md-4">
+        <form class="form p-4" method="post">
+          <h3 class="text-center mb-3 open-sans">Editar perfil</h3>
+        <div class="row justify-content-center align-items-center">
+          <div class="divisor"></div>
+        </div>
+          <p class="text-center mb-2 open-sans">Preencha os campos abaixo para editar seus dados pessoais. </p>
 
 <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= f.error_notification %>
@@ -10,37 +18,33 @@
       <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
     <% end %>
 
-    <%= f.input :first_name,
+    <%= f.input :first_name, :label => 'Nome',
                 required: false,
                 autofocus: true,
                 input_html: { autocomplete: "first-name" } %>
-    <%= f.input :last_name,
+    <%= f.input :last_name, :label => 'Sobrenome',
                 required: false,
                 input_html: { autocomplete: "last-name" } %>
-    <%= f.input :phone,
+    <%= f.input :phone, :label => 'Celular',
                 required: false,
                 autofocus: true,
                 input_html: { autocomplete: "phone" } %>
-    <%= f.input :password,
-                hint: "leave it blank if you don't want to change it",
+    <%= f.input :password, :label => 'Nova senha',
+                hint: "Deixe em branco caso não deseje alterá-la",
                 required: false,
                 input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :current_password,
-                hint: "we need your current password to confirm your changes",
+    <%= f.input :current_password, :label => 'Senha atual',
+                hint: "Precisamos dela para salvar suas alterações",
                 required: true,
                 input_html: { autocomplete: "current-password" } %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Update" %>
+  <div class="form-actions row justify-content-center">
+    <%= f.submit "Atualizar perfil", class:"btn-custom pink"%>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</form>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,41 @@
-<h2>Sign up</h2>
+<div class="container mt-5">
+  <div class="row justify-content-center align-items-center" style="margin-top: 100px;">
+    <div class="col-md-3">
+        <h3 class="text-center open-sans">Criar conta</h3>
+        <div class="row justify-content-center align-items-center">
+          <div class="divisor"></div>
+        </div>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
+        <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+            <%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :first_name,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "first-name" } %>
-    <%= f.input :last_name,
-                required: true,
-                input_html: { autocomplete: "last-name" } %>
-    <%= f.input :email,
-                required: true,
-                input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
-                required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :phone,
-                required: false,
-                input_html: { autocomplete: "phone" } %>
+          <div class="form-inputs open-sans">
+            <%= f.input :first_name, :label => 'Nome',
+                        required: true,
+                        autofocus: true,
+                        input_html: { autocomplete: "first-name" } %>
+            <%= f.input :last_name, :label => 'Sobrenome',
+                        required: true,
+                        input_html: { autocomplete: "last-name" } %>
+            <%= f.input :email, :label => 'Email',
+                        required: true,
+                        input_html: { autocomplete: "email" }%>
+            <%= f.input :password, :label => 'Senha',
+                        required: true,
+                        hint: ("Mínimo de #{@minimum_password_length} caracteres" if @minimum_password_length),
+                        input_html: { autocomplete: "new-password" } %>
+
+            <%= f.input :phone, :label => 'Celular',
+                        required: false,
+                        input_html: { autocomplete: "phone" } %>
+          </div>
+
+            <div class="row justify-content-center">
+              <div class="form-actions">
+                <%= f.submit "Criar nova conta", class:"btn-custom pink"%>
+              </div>
+            </div>
+        <% end %>
+    </div>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,20 +1,32 @@
-<h2>Log in</h2>
+<div class="container mt-5">
+  <div class="row justify-content-center align-items-center" style="margin-top: 150px;">
+    <div class="col-md-3">
+        <h3 class="text-center open-sans">Acesse sua conta</h3>
+        <div class="row justify-content-center align-items-center">
+          <div class="divisor"></div>
+        </div>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+          <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+            <div class="form-inputs open-sans">
+              <%= f.input :email, :label => 'Email',
+                  required: false,
+                   autofocus: true,
+                   input_html: { autocomplete: "email" } %>
+              <%= f.input :password, :label => 'Senha',
+                        required: false,
+                        input_html: { autocomplete: "current-password" } %>
+                        <%= link_to "Esqueceu sua senha?", new_password_path(resource_name), class: "link-devise" %>
+            </div>
+            <div class="row justify-content-center">
+            <div class="form-actions">
+              <%= f.submit "Entrar", class:"btn-custom pink"%>
+            </div>
+            </div>
+              <% end %>
+      </div>
   </div>
+</div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
 
-<%= render "devise/shared/links" %>
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
 
     <%= yield %>
 
-    <%= render 'shared/footer' %>
+    <% unless controller_name == "sessions" || controller_name == "registrations" || controller_name == "passwords" %>
+      <%= render 'shared/footer' %>
+    <% end %>
+
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,7 +9,7 @@
 
       <div class="botoes">
         <button type="button" class="button-white mr-2">Reportar pet perdido</button>
-        <button type="button" class="button-pink">Achei um pet</button>
+        <button type="button" class="btn-custom pink">Achei um pet</button>
       </div>
 
     </div>


### PR DESCRIPTION
- Layout done for devise pages (sign in, sign up, forgot password, edit user);
- Minor fixes on CSS for buttons displayed across the site;
- Added logic to hide footer from certain pages on application.rb;
- Minor changes on homepage.

Screenshots:

![Screen Shot 2020-06-10 at 11 57 45](https://user-images.githubusercontent.com/11315540/84284010-11865a00-ab12-11ea-9024-0de84ab16784.png)
![Screen Shot 2020-06-10 at 11 57 59](https://user-images.githubusercontent.com/11315540/84284017-13501d80-ab12-11ea-9a69-5ec445e97cd6.png)
![Screen Shot 2020-06-10 at 11 58 10](https://user-images.githubusercontent.com/11315540/84284019-13501d80-ab12-11ea-80c3-1ff0ec3bff50.png)
![Screen Shot 2020-06-10 at 11 58 24](https://user-images.githubusercontent.com/11315540/84284021-13e8b400-ab12-11ea-8db0-4b067d934e43.png)
