### PR TITLE
change href on facebook to static url - test if works on production mode

### DIFF
--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -28,7 +28,7 @@
                 <% end %>
                 <%= link_to pet_imgkit_path(pet), :title => "Compartilhar" do %>
                   <p class="card-text text-center mt-4 link-icon">
-                    <i class="fb-share-button" data-href='request.base_url/pets/<%="#{pet.id}"%>/imgkit'data-layout="button_count"></i>
+                    <i class="fb-share-button" data-href='https://robyn.com.br/pets/15/imgkit' data-layout="button_count"></i>
                     <!--<i class="fas fa-share-alt" data-href='request.base_url/pets/<%="#{pet.id}"%>/imgkit'></i></p> -->
                   </p>
                 <% end %>


### PR DESCRIPTION
request.base_url did not work on production.
changed to static robin-poster url to test functionality.

will add pet_id interpolation if static url works